### PR TITLE
Refresh admin panel UI for new dashboard theme

### DIFF
--- a/dashboard/admin/admin.css
+++ b/dashboard/admin/admin.css
@@ -1,20 +1,292 @@
-:root { --panel-2:#0e141d }
+:root {
+  --font-mono: "JetBrains Mono", "Fira Code", "Source Code Pro", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
 
-.row{display:flex;align-items:center;justify-content:space-between}
-.row.gap{gap:10px}
-.btn{padding:8px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.04);color:var(--text);cursor:pointer}
-.btn:hover{border-color:rgba(125,211,252,.35)}
-.btn.ok{background:rgba(0,184,148,.15);color:var(--green)}
+.admin-page-content {
+  gap: 28px;
+}
 
-.modal{position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center}
-.panel{background:linear-gradient(180deg,var(--panel),var(--panel-2));border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:18px;max-width:360px;width:90%}
+.admin-intro {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 24px;
+}
 
-.kv-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-.kv-grid .group{display:flex;flex-direction:column;gap:6px}
-.kv-grid label{font-size:12px;color:var(--muted)}
-.kv-grid input{padding:10px;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.03);color:var(--text)}
-@media (max-width:640px){ .kv-grid{grid-template-columns:1fr} }
+.admin-intro h2 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 20px;
+}
 
-.chip{display:inline-block;padding:2px 8px;border-radius:999px;border:1px solid rgba(255,255,255,.1);font-size:12px}
-.chip.ok{background:rgba(0,184,148,.15);color:var(--green);border-color:rgba(0,184,148,.35)}
-.chip.bad{background:rgba(255,99,71,.15);color:#ff7961;border-color:rgba(255,99,71,.35)}
+.admin-intro-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.admin-intro-list li {
+  position: relative;
+  padding-left: 30px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.admin-intro-list li::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 18px;
+  height: 18px;
+  transform: translateY(-50%);
+  border-radius: 8px;
+  border: 1px solid rgba(125, 211, 252, 0.4);
+  background:
+    linear-gradient(140deg, rgba(125, 211, 252, 0.2), rgba(56, 189, 248, 0.05));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.admin-intro-list li::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 6px;
+  width: 6px;
+  height: 6px;
+  transform: translateY(-50%) rotate(45deg);
+  border-right: 2px solid var(--accent);
+  border-bottom: 2px solid var(--accent);
+}
+
+.admin-root {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.admin-placeholder {
+  border-style: dashed;
+  border-color: rgba(125, 211, 252, 0.24);
+  background:
+    linear-gradient(180deg, rgba(125, 211, 252, 0.08), rgba(125, 211, 252, 0.02));
+}
+
+.placeholder-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.pill-protected {
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--accent);
+  border-color: rgba(56, 189, 248, 0.42);
+}
+
+.pill-locked {
+  background: rgba(248, 113, 113, 0.16);
+  color: #fca5a5;
+  border-color: rgba(248, 113, 113, 0.32);
+}
+
+.chip.neutral {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-muted);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.row.gap {
+  gap: 12px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--stroke);
+  background: var(--surface-subtle);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: none;
+  cursor: pointer;
+  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 14px 38px rgba(15, 23, 42, 0.35);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn.ok {
+  background: linear-gradient(180deg, rgba(34, 197, 94, 0.18), rgba(34, 197, 94, 0.08));
+  border-color: rgba(34, 197, 94, 0.35);
+  color: #4ade80;
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.32);
+  color: var(--text-muted);
+}
+
+.btn.ghost:hover,
+.btn.ghost:focus-visible {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(16px);
+  z-index: 100;
+}
+
+.panel {
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 28px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-strong);
+  border: 1px solid var(--stroke-strong);
+  box-shadow: var(--shadow);
+}
+
+.panel-header h3 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field label {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.field input,
+.panel textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--stroke);
+  background: var(--surface-subtle);
+  color: var(--text);
+  font: 14px/1.4 var(--font-sans);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.panel textarea {
+  min-height: 40vh;
+  resize: vertical;
+  font-family: var(--font-mono);
+}
+
+.field input:focus-visible,
+.panel textarea:focus-visible {
+  outline: none;
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.25);
+}
+
+.feedback {
+  min-height: 18px;
+  font-size: 13px;
+  color: #fca5a5;
+}
+
+.table-state {
+  display: block;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  background: var(--surface-subtle);
+}
+
+.table-message td {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.panel-actions {
+  justify-content: flex-end;
+}
+
+#svc-table tbody tr {
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+#svc-table tbody tr:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+}
+
+#svc-table td {
+  vertical-align: middle;
+}
+
+#svc-table .row.gap {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+@media (max-width: 900px) {
+  .admin-intro {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-intro-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .admin-header {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+  }
+
+  .admin-header .header-actions {
+    justify-content: flex-start;
+  }
+
+  .admin-intro-list {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    padding: 24px;
+  }
+}

--- a/dashboard/admin/admin.css
+++ b/dashboard/admin/admin.css
@@ -1,20 +1,17 @@
 :root {
-  --font-mono: "JetBrains Mono", "Fira Code", "Source Code Pro", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-mono: "JetBrains Mono","Fira Code","Source Code Pro",ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
 }
 
-.admin-page-content {
-  gap: 28px;
-}
+.admin-page-content { gap: 28px; }
 
 .admin-intro {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0,2fr) minmax(0,1fr);
   gap: 24px;
 }
 
 .admin-intro h2 {
-  margin-top: 0;
-  margin-bottom: 12px;
+  margin: 0 0 12px;
   font-size: 20px;
 }
 
@@ -23,41 +20,12 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
 .admin-intro-list li {
-  position: relative;
-  padding-left: 30px;
   font-size: 14px;
   color: var(--text-muted);
-}
-
-.admin-intro-list li::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 18px;
-  height: 18px;
-  transform: translateY(-50%);
-  border-radius: 8px;
-  border: 1px solid rgba(125, 211, 252, 0.4);
-  background:
-    linear-gradient(140deg, rgba(125, 211, 252, 0.2), rgba(56, 189, 248, 0.05));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
-}
-
-.admin-intro-list li::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 6px;
-  width: 6px;
-  height: 6px;
-  transform: translateY(-50%) rotate(45deg);
-  border-right: 2px solid var(--accent);
-  border-bottom: 2px solid var(--accent);
 }
 
 .admin-root {
@@ -66,11 +34,10 @@
   gap: 24px;
 }
 
+/* Subtle auth placeholder */
 .admin-placeholder {
-  border-style: dashed;
-  border-color: rgba(125, 211, 252, 0.24);
-  background:
-    linear-gradient(180deg, rgba(125, 211, 252, 0.08), rgba(125, 211, 252, 0.02));
+  border: 1px dashed rgba(125,211,252,0.24);
+  background: linear-gradient(180deg, rgba(125,211,252,0.06), rgba(125,211,252,0.02));
 }
 
 .placeholder-head {
@@ -80,27 +47,8 @@
   gap: 24px;
 }
 
-.pill-protected {
-  background: rgba(56, 189, 248, 0.16);
-  color: var(--accent);
-  border-color: rgba(56, 189, 248, 0.42);
-}
-
-.pill-locked {
-  background: rgba(248, 113, 113, 0.16);
-  color: #fca5a5;
-  border-color: rgba(248, 113, 113, 0.32);
-}
-
-.chip.neutral {
-  background: rgba(148, 163, 184, 0.16);
-  color: var(--text-muted);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-}
-
-.row.gap {
-  gap: 12px;
-}
+/* Buttons */
+.row.gap { gap: 12px; }
 
 .btn {
   display: inline-flex;
@@ -115,7 +63,6 @@
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.03em;
-  text-transform: none;
   cursor: pointer;
   transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
 }
@@ -123,27 +70,22 @@
 .btn:hover,
 .btn:focus-visible {
   border-color: var(--accent);
-  box-shadow: 0 14px 38px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 12px 30px rgba(15,23,42,0.28);
   outline: none;
   transform: translateY(-1px);
 }
 
-.btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
+.btn:disabled { opacity: .6; cursor: not-allowed; transform: none; box-shadow: none; }
 
 .btn.ok {
-  background: linear-gradient(180deg, rgba(34, 197, 94, 0.18), rgba(34, 197, 94, 0.08));
-  border-color: rgba(34, 197, 94, 0.35);
+  background: linear-gradient(180deg, rgba(34,197,94,0.18), rgba(34,197,94,0.08));
+  border-color: rgba(34,197,94,0.35);
   color: #4ade80;
 }
 
 .btn.ghost {
   background: transparent;
-  border-color: rgba(148, 163, 184, 0.32);
+  border-color: rgba(148,163,184,0.32);
   color: var(--text-muted);
 }
 
@@ -153,6 +95,7 @@
   color: var(--text);
 }
 
+/* Modal + panel */
 .modal {
   position: fixed;
   inset: 0;
@@ -160,13 +103,13 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(2, 6, 23, 0.72);
+  background: rgba(2,6,23,0.72);
   backdrop-filter: blur(16px);
   z-index: 100;
 }
 
 .panel {
-  width: min(420px, 100%);
+  width: min(420px,100%);
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -177,16 +120,9 @@
   box-shadow: var(--shadow);
 }
 
-.panel-header h3 {
-  margin: 0;
-  font-size: 20px;
-}
+.panel-header h3 { margin: 0; font-size: 20px; }
 
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
+.field { display: flex; flex-direction: column; gap: 8px; }
 
 .field label {
   font-size: 12px;
@@ -217,32 +153,23 @@
 .panel textarea:focus-visible {
   outline: none;
   border-color: var(--accent-strong);
-  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.25);
+  box-shadow: 0 0 0 3px rgba(125,211,252,0.25);
 }
 
-.feedback {
-  min-height: 18px;
-  font-size: 13px;
-  color: #fca5a5;
-}
+.feedback { min-height: 18px; font-size: 13px; color: #fca5a5; }
 
+/* Services table */
 .table-state {
   display: block;
   padding: 18px;
   border-radius: var(--radius-md);
-  border: 1px dashed rgba(148, 163, 184, 0.32);
+  border: 1px dashed rgba(148,163,184,0.32);
   background: var(--surface-subtle);
 }
 
-.table-message td {
-  background: transparent;
-  border: none;
-  padding: 0;
-}
+.table-message td { background: transparent; border: none; padding: 0; }
 
-.panel-actions {
-  justify-content: flex-end;
-}
+.panel-actions { justify-content: flex-end; }
 
 #svc-table tbody tr {
   transition: transform var(--transition), box-shadow var(--transition);
@@ -250,43 +177,25 @@
 
 #svc-table tbody tr:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 16px 36px rgba(15,23,42,0.30);
 }
 
-#svc-table td {
-  vertical-align: middle;
-}
+#svc-table td { vertical-align: middle; }
 
 #svc-table .row.gap {
   flex-wrap: wrap;
   justify-content: flex-start;
 }
 
+/* Mobile */
 @media (max-width: 900px) {
-  .admin-intro {
-    grid-template-columns: 1fr;
-  }
-
-  .admin-intro-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  .admin-intro { grid-template-columns: 1fr; }
+  .admin-intro-list { grid-template-columns: repeat(2, minmax(0,1fr)); }
 }
 
 @media (max-width: 640px) {
-  .admin-header {
-    grid-template-columns: 1fr;
-    align-items: flex-start;
-  }
-
-  .admin-header .header-actions {
-    justify-content: flex-start;
-  }
-
-  .admin-intro-list {
-    grid-template-columns: 1fr;
-  }
-
-  .panel {
-    padding: 24px;
-  }
+  .admin-header { grid-template-columns: 1fr; align-items: flex-start; }
+  .admin-header .header-actions { justify-content: flex-start; }
+  .admin-intro-list { grid-template-columns: 1fr; }
+  .panel { padding: 24px; }
 }

--- a/dashboard/admin/admin.html
+++ b/dashboard/admin/admin.html
@@ -22,29 +22,18 @@
         <div class="brand-mark" aria-hidden="true">⚙️</div>
         <div class="brand-copy">
           <h1>Admin Panel</h1>
-          <p class="muted">Control services, manage environments, stay in sync.</p>
+          <p class="muted">Manage services and environment files on BigRedPi.</p>
         </div>
-      </div>
-
-      <div class="header-meta">
-        <div class="meta-stack">
-          <span class="meta-label">Status</span>
-          <span class="meta-value">Secure</span>
-        </div>
-        <span class="pill pill-protected">Protected</span>
       </div>
 
       <div class="header-actions">
-        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to light theme">
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch theme">
           <span class="theme-icon" aria-hidden="true"></span>
           <span class="theme-label">Theme</span>
         </button>
         <a class="admin-btn" href="/" aria-label="Return to dashboard">
           <span class="admin-icon">🏠</span>
-          <span class="admin-text">
-            <strong>Dashboard</strong>
-            <small>/</small>
-          </span>
+          <span class="admin-text"><strong>Dashboard</strong></span>
         </a>
       </div>
     </header>
@@ -52,13 +41,13 @@
     <main class="page-content admin-page-content">
       <section class="card admin-intro">
         <div class="admin-intro-copy">
-          <h2>Administrator Toolkit</h2>
-          <p class="muted">Authenticate to orchestrate services, trigger restarts, and edit runtime configuration without leaving the dashboard aesthetic.</p>
+          <h2>Tools</h2>
+          <p class="muted">Start/stop/restart services and edit their <code>.env</code> files in one place.</p>
         </div>
         <ul class="admin-intro-list">
-          <li><span>One-click start, stop, and restart controls</span></li>
-          <li><span>Direct .env editing with instant saves</span></li>
-          <li><span>Session-aware security with modal login</span></li>
+          <li><span>Service controls</span></li>
+          <li><span>Inline <code>.env</code> editor</span></li>
+          <li><span>Password-gated access</span></li>
         </ul>
       </section>
 
@@ -66,26 +55,25 @@
         <section class="card admin-placeholder" aria-live="polite">
           <div class="placeholder-head">
             <div>
-              <h2>Authentication Required</h2>
-              <p class="muted">Use the administrator password to unlock service controls.</p>
+              <h2>Authentication required</h2>
+              <p class="muted">Enter the admin password to view and manage services.</p>
             </div>
-            <span class="pill pill-locked">Locked</span>
           </div>
         </section>
       </div>
     </main>
 
     <footer class="page-footer glass-panel">
-      <small>Admin actions are logged locally</small>
-      <small>Session <span class="pill pill-protected">Protected</span></small>
+      <small>Admin actions are logged locally on Pi.</small>
     </footer>
   </div>
 
+  <!-- Login Modal -->
   <div class="modal" id="login-modal" role="dialog" aria-modal="true" aria-labelledby="login-title" aria-describedby="login-description" style="display:none">
     <div class="panel">
       <header class="panel-header">
-        <h3 id="login-title">Administrator Login</h3>
-        <p id="login-description" class="muted">Enter the admin password to continue.</p>
+        <h3 id="login-title">Admin login</h3>
+        <p id="login-description" class="muted">Enter the password to continue.</p>
       </header>
       <div class="field">
         <label for="pw">Password</label>
@@ -117,7 +105,6 @@
     }
 
     apply(initial);
-
     toggle.addEventListener('click', () => {
       const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
       apply(next);

--- a/dashboard/admin/admin.html
+++ b/dashboard/admin/admin.html
@@ -4,38 +4,126 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>BigRedPi · Admin</title>
+  <link rel="icon" href="/favicon.ico" />
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/admin/assets/admin.css" />
 </head>
-<body>
-  <header>
-    <h1>Admin</h1>
-    <div class="meta"><span class="pill">Protected</span></div>
-  </header>
+<body data-theme="dark">
+  <div class="bg-canvas" aria-hidden="true">
+    <span class="glow glow-1"></span>
+    <span class="glow glow-2"></span>
+    <span class="glow glow-3"></span>
+    <span class="grid-overlay"></span>
+  </div>
 
-  <main id="admin-root" style="min-height:40vh">
-    <!-- JS will either show login modal or render the protected shell -->
-  </main>
-
-  <!-- Login Modal (hidden until needed) -->
-  <div class="modal" id="login-modal" style="display:none">
-    <div class="panel">
-      <h3>Administrator Login</h3>
-      <p class="muted">Enter the admin password to continue.</p>
-      <div class="kv-grid">
-        <div class="group" style="grid-column:1/-1">
-          <label for="pw">Password</label>
-          <input id="pw" type="password" placeholder="••••••••" autocomplete="current-password" />
+  <div class="page-shell">
+    <header class="page-header glass-panel admin-header">
+      <div class="brand">
+        <div class="brand-mark" aria-hidden="true">⚙️</div>
+        <div class="brand-copy">
+          <h1>Admin Panel</h1>
+          <p class="muted">Control services, manage environments, stay in sync.</p>
         </div>
       </div>
-      <div class="row gap" style="margin-top:12px">
-        <button class="btn" id="btn-cancel">Cancel</button>
-        <button class="btn ok" id="btn-login">Login</button>
+
+      <div class="header-meta">
+        <div class="meta-stack">
+          <span class="meta-label">Status</span>
+          <span class="meta-value">Secure</span>
+        </div>
+        <span class="pill pill-protected">Protected</span>
       </div>
-      <div class="muted" id="login-err" style="margin-top:8px"></div>
+
+      <div class="header-actions">
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to light theme">
+          <span class="theme-icon" aria-hidden="true"></span>
+          <span class="theme-label">Theme</span>
+        </button>
+        <a class="admin-btn" href="/" aria-label="Return to dashboard">
+          <span class="admin-icon">🏠</span>
+          <span class="admin-text">
+            <strong>Dashboard</strong>
+            <small>/</small>
+          </span>
+        </a>
+      </div>
+    </header>
+
+    <main class="page-content admin-page-content">
+      <section class="card admin-intro">
+        <div class="admin-intro-copy">
+          <h2>Administrator Toolkit</h2>
+          <p class="muted">Authenticate to orchestrate services, trigger restarts, and edit runtime configuration without leaving the dashboard aesthetic.</p>
+        </div>
+        <ul class="admin-intro-list">
+          <li><span>One-click start, stop, and restart controls</span></li>
+          <li><span>Direct .env editing with instant saves</span></li>
+          <li><span>Session-aware security with modal login</span></li>
+        </ul>
+      </section>
+
+      <div id="admin-root" class="admin-root">
+        <section class="card admin-placeholder" aria-live="polite">
+          <div class="placeholder-head">
+            <div>
+              <h2>Authentication Required</h2>
+              <p class="muted">Use the administrator password to unlock service controls.</p>
+            </div>
+            <span class="pill pill-locked">Locked</span>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer class="page-footer glass-panel">
+      <small>Admin actions are logged locally</small>
+      <small>Session <span class="pill pill-protected">Protected</span></small>
+    </footer>
+  </div>
+
+  <div class="modal" id="login-modal" role="dialog" aria-modal="true" aria-labelledby="login-title" aria-describedby="login-description" style="display:none">
+    <div class="panel">
+      <header class="panel-header">
+        <h3 id="login-title">Administrator Login</h3>
+        <p id="login-description" class="muted">Enter the admin password to continue.</p>
+      </header>
+      <div class="field">
+        <label for="pw">Password</label>
+        <input id="pw" type="password" placeholder="••••••••" autocomplete="current-password" />
+      </div>
+      <div class="row gap panel-actions">
+        <button class="btn ghost" id="btn-cancel" type="button">Cancel</button>
+        <button class="btn ok" id="btn-login" type="button">Login</button>
+      </div>
+      <div class="feedback" id="login-err" role="alert"></div>
     </div>
   </div>
 
+  <script>
+  (function(){
+    const root = document.body;
+    const toggle = document.getElementById('theme-toggle');
+    if(!toggle) return;
+
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const saved = localStorage.getItem('dashboard-theme');
+    const initial = saved || (prefersDark ? 'dark' : 'light');
+
+    function apply(theme){
+      root.setAttribute('data-theme', theme);
+      toggle.setAttribute('aria-label', `Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`);
+      toggle.dataset.mode = theme;
+      localStorage.setItem('dashboard-theme', theme);
+    }
+
+    apply(initial);
+
+    toggle.addEventListener('click', () => {
+      const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      apply(next);
+    });
+  })();
+  </script>
   <script src="/admin/assets/admin.js"></script>
 </body>
 </html>

--- a/dashboard/admin/admin.js
+++ b/dashboard/admin/admin.js
@@ -55,17 +55,17 @@ function renderProtectedShell() {
   const header = el("div", { class: "row" }, [
     el("h2", { text: "Services" }),
     el("div", { class: "row gap" }, [
-      el("button", { class: "btn", id: "btn-refresh", text: "Refresh" }),
-      el("button", { class: "btn", id: "btn-logout", text: "Logout" }),
+      el("button", { class: "btn", id: "btn-refresh", text: "Refresh", type: "button" }),
+      el("button", { class: "btn ghost", id: "btn-logout", text: "Logout", type: "button" }),
     ]),
   ]);
-  const table = el("table", { id: "svc-table", style: "width:100%;border-collapse:separate;border-spacing:0 6px" });
+  const table = el("table", { id: "svc-table" });
   table.innerHTML = `
     <thead><tr>
-      <th style="text-align:left;padding:6px 8px">Service</th>
-      <th style="text-align:left;padding:6px 8px">Status</th>
-      <th style="text-align:left;padding:6px 8px">Actions</th>
-      <th style="text-align:left;padding:6px 8px">.env</th>
+      <th scope="col">Service</th>
+      <th scope="col">Status</th>
+      <th scope="col">Actions</th>
+      <th scope="col">.env</th>
     </tr></thead>
     <tbody></tbody>
   `;
@@ -76,33 +76,39 @@ function renderProtectedShell() {
 
   async function load() {
     const tbody = table.querySelector("tbody");
-    tbody.innerHTML = `<tr><td colspan="4" class="muted" style="padding:8px">Loading…</td></tr>`;
+    tbody.innerHTML = `<tr class="table-message"><td colspan="4"><span class="table-state muted">Loading…</span></td></tr>`;
     try {
       const data = await api("/api/admin/services");
+      const services = data.services || [];
       tbody.innerHTML = "";
-      (data.services || []).forEach(s => {
+      if (!services.length) {
+        tbody.innerHTML = `<tr class="table-message"><td colspan="4"><span class="table-state muted">No services reported yet.</span></td></tr>`;
+        return;
+      }
+
+      services.forEach(s => {
         const status = s.running === true ? ["ok", "Running"]
                     : s.running === false ? ["bad", "Stopped"]
-                    : ["", "Unknown"];
+                    : ["neutral", "Unknown"];
         const tr = document.createElement("tr");
         tr.innerHTML = `
-          <td style="padding:6px 8px">${s.label}</td>
-          <td style="padding:6px 8px"><span class="chip ${status[0]}">${status[1]}</span></td>
-          <td style="padding:6px 8px">
+          <td>${s.label}</td>
+          <td><span class="chip ${status[0]}">${status[1]}</span></td>
+          <td>
             <div class="row gap">
-              <button class="btn" data-act="start"   data-id="${s.id}">Start</button>
-              <button class="btn" data-act="stop"    data-id="${s.id}">Stop</button>
-              <button class="btn" data-act="restart" data-id="${s.id}">Restart</button>
+              <button class="btn" type="button" data-act="start"   data-id="${s.id}">Start</button>
+              <button class="btn" type="button" data-act="stop"    data-id="${s.id}">Stop</button>
+              <button class="btn" type="button" data-act="restart" data-id="${s.id}">Restart</button>
             </div>
           </td>
-          <td style="padding:6px 8px">
-            <button class="btn" data-edit="${s.id}">${s.hasEnv ? "Edit Env" : "Create Env"}</button>
+          <td>
+            <button class="btn" type="button" data-edit="${s.id}">${s.hasEnv ? "Edit Env" : "Create Env"}</button>
           </td>
         `;
         tbody.appendChild(tr);
       });
     } catch (e) {
-      tbody.innerHTML = `<tr><td colspan="4" class="muted" style="padding:8px">Failed: ${e?.data?.error || e.message}</td></tr>`;
+      tbody.innerHTML = `<tr class="table-message"><td colspan="4"><span class="table-state muted">Failed: ${e?.data?.error || e.message}</span></td></tr>`;
     }
   }
 
@@ -201,13 +207,13 @@ async function openEnvEditor(id) {
   const modal = el("div", { class: "modal" });
   const panel = el("div", { class: "panel" });
   const title = el("h3", { text: `Edit .env (${id})` });
-  const ta = el("textarea", { style: "width:100%;height:40vh" });
+  const ta = el("textarea");
   ta.value = meta.text || "";
   const info = el("div", { class: "muted", text: meta.exists ? meta.path : "(file will be created on save)" });
 
   const row = el("div", { class: "row gap", style: "margin-top:12px" }, [
-    el("button", { class: "btn", id: "env-cancel", text: "Cancel" }),
-    el("button", { class: "btn ok", id: "env-save", text: "Save" }),
+    el("button", { class: "btn ghost", id: "env-cancel", text: "Cancel", type: "button" }),
+    el("button", { class: "btn ok", id: "env-save", text: "Save", type: "button" }),
   ]);
   panel.appendChild(title); panel.appendChild(info); panel.appendChild(ta); panel.appendChild(row);
   modal.appendChild(panel); document.body.appendChild(modal);

--- a/dashboard/admin/admin.js
+++ b/dashboard/admin/admin.js
@@ -88,7 +88,7 @@ function renderProtectedShell() {
 
       services.forEach(s => {
         const status = s.running === true ? ["ok", "Running"]
-                    : s.running === false ? ["bad", "Stopped"]
+                    : s.running === false ? ["neutral", "Stopped"]
                     : ["neutral", "Unknown"];
         const tr = document.createElement("tr");
         tr.innerHTML = `

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -38,7 +38,7 @@
       <span class="theme-icon" aria-hidden="true"></span>
       <span class="theme-label">Theme</span>
     </button>
-    <a class="admin-btn" href="/admin" target="_blank" rel="noopener noreferrer" aria-label="Open Admin Panel">
+    <a class="admin-btn" href="/admin" rel="noopener noreferrer" aria-label="Open Admin Panel">
       <span class="admin-icon">⚙️</span>
       <span class="admin-text">
         <strong>Admin</strong>


### PR DESCRIPTION
## Summary
- restyle the admin HTML shell to share the dashboard background, header, and theme toggle
- overhaul admin-specific CSS for cards, modals, buttons, and status chips to match the refreshed glassmorphism aesthetic
- refine the admin JavaScript table rendering for polished empty/loading states and neutral status styling

## Testing
- not run (UI only)


------
https://chatgpt.com/codex/tasks/task_e_68e5e1c7faa88322972ef7651db0c577